### PR TITLE
feat: implement directory tree display in doc-chimp overview command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14715,7 +14715,7 @@
       }
     },
     "packages/chimp-core": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "chalk": "^5.4.1",
         "commander": "^14.0.0",
@@ -14728,7 +14728,7 @@
       }
     },
     "packages/doc-chimp": {
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^22.15.29",
@@ -14736,6 +14736,7 @@
         "chimp-core": "*",
         "commander": "^14.0.0",
         "comment-parser": "^1.4.1",
+        "fast-glob": "^3.3.3",
         "globby": "^14.1.0",
         "simple-git": "^3.27.0",
         "ts-node": "^10.9.2",
@@ -14753,7 +14754,7 @@
       }
     },
     "packages/git-chimp": {
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@octokit/rest": "^22.0.0",

--- a/packages/chimp-core/src/cli/config.ts
+++ b/packages/chimp-core/src/cli/config.ts
@@ -1,7 +1,8 @@
-import chalk from 'chalk';
+import { getChalk } from 'src/utils/getChalk';
 import { writeChimpConfig, loadChimpConfig } from '../config';
 
-export function listConfig(scope: string) {
+export async function listConfig(scope: string) {
+  const chalk = await getChalk();
   const config = loadChimpConfig(scope);
 
   if (Object.keys(config).length === 0) {
@@ -26,7 +27,8 @@ export function listConfig(scope: string) {
   process.exit(0);
 }
 
-export function getConfig(scope: string, key: string) {
+export async function getConfig(scope: string, key: string) {
+  const chalk = await getChalk();
   const config = loadChimpConfig(scope);
   const val = config[key];
 
@@ -52,7 +54,12 @@ export function getConfig(scope: string, key: string) {
   }
 }
 
-export function setConfig(scope: string, key: string, value: string) {
+export async function setConfig(
+  scope: string,
+  key: string,
+  value: string
+) {
+  const chalk = await getChalk();
   writeChimpConfig({ [key]: value }, { scope, location: 'global' });
   console.log(
     chalk.greenBright(

--- a/packages/chimp-core/src/utils/getChalk.ts
+++ b/packages/chimp-core/src/utils/getChalk.ts
@@ -1,0 +1,1 @@
+export const getChalk = async () => (await import('chalk')).default;

--- a/packages/doc-chimp/package.json
+++ b/packages/doc-chimp/package.json
@@ -31,6 +31,7 @@
     "chimp-core": "*",
     "commander": "^14.0.0",
     "comment-parser": "^1.4.1",
+    "fast-glob": "^3.3.3",
     "globby": "^14.1.0",
     "simple-git": "^3.27.0",
     "ts-node": "^10.9.2",

--- a/packages/doc-chimp/src/commands/index.ts
+++ b/packages/doc-chimp/src/commands/index.ts
@@ -26,6 +26,10 @@ export function runCLI() {
       'Display a directory tree based on include/exclude patterns from your .chimprc'
     )
     .option('--pretty', 'Prettify output with colours')
+    .option(
+      '--include <globs...>',
+      'Override include globs from .chimprc'
+    )
     .action(handleOverview);
 
   program.parse(process.argv);

--- a/packages/doc-chimp/src/commands/index.ts
+++ b/packages/doc-chimp/src/commands/index.ts
@@ -22,7 +22,10 @@ export function runCLI() {
 
   program
     .command('overview')
-    .description('Generate a summary of recent commits')
+    .description(
+      'Display a directory tree based on include/exclude patterns from your .chimprc'
+    )
+    .option('--pretty', 'Prettify output with colours')
     .action(handleOverview);
 
   program.parse(process.argv);

--- a/packages/doc-chimp/src/commands/overview.ts
+++ b/packages/doc-chimp/src/commands/overview.ts
@@ -7,7 +7,7 @@ type FileTree = {
   [key: string]: FileTree | null;
 };
 
-function insertIntoTree(tree: FileTree, parts: string[]) {
+export function insertIntoTree(tree: FileTree, parts: string[]) {
   const [head, ...rest] = parts;
   if (!head) return;
 

--- a/packages/doc-chimp/src/commands/overview.ts
+++ b/packages/doc-chimp/src/commands/overview.ts
@@ -1,11 +1,67 @@
 import { DocChimpConfig, loadChimpConfig } from 'chimp-core';
-import { writeMarkdown } from '../generator/markdown.js';
-import { getCommits } from '../parser/git.js';
+import fg from 'fast-glob';
+import path from 'node:path';
+import chalk from 'chalk';
 
-export async function handleOverview() {
+export async function handleOverview({
+  pretty,
+}: {
+  pretty?: boolean;
+}) {
   const config = loadChimpConfig('docChimp') as DocChimpConfig;
-  const commits = await getCommits();
-  const content = `# Recent Commits\n\n${commits.join('\n')}`;
-  writeMarkdown('overview.md', content, config.outputDir);
-  console.log('✅ doc-chimp: docs/overview.md generated.');
+  const { include, exclude, outputDir } = config;
+
+  const files = await fg(include, {
+    ignore: exclude,
+    onlyFiles: true,
+    cwd: process.cwd(),
+    absolute: true,
+  });
+
+  const tree: Record<string, string[]> = {};
+
+  for (const file of files) {
+    const relPath = path.relative(process.cwd(), file);
+    const dir = path.dirname(relPath);
+
+    if (!tree[dir]) {
+      tree[dir] = [];
+    }
+
+    tree[dir].push(path.basename(relPath));
+  }
+
+  if (pretty) {
+    console.log(chalk.bold('\n📁 Project Structure Overview:\n'));
+  } else {
+    console.log('\n📁 Project Structure Overview:\n');
+  }
+
+  const printTree = (dir: string, depth = 0) => {
+    const indent = '  '.repeat(depth);
+    const label = dir || '.';
+
+    if (pretty) {
+      console.log(`${indent}${chalk.blue.bold(label + '/')}`);
+    } else {
+      console.log(`${indent}${label}/`);
+    }
+
+    const children = (tree[dir] || []).sort();
+
+    for (const child of children) {
+      const childText = `${indent}  └── ${child}`;
+      console.log(pretty ? chalk.green(childText) : childText);
+    }
+
+    const subdirs = Object.keys(tree)
+      .filter((d) => path.dirname(d) === dir && d !== dir)
+      .sort();
+
+    for (const sub of subdirs) {
+      printTree(sub, depth + 1);
+    }
+  };
+
+  printTree('');
 }

--- a/packages/doc-chimp/tests/overview.test.ts
+++ b/packages/doc-chimp/tests/overview.test.ts
@@ -1,0 +1,62 @@
+import path from 'node:path';
+import { describe, expect, it } from '@jest/globals';
+import { insertIntoTree } from '../src/commands/overview.js';
+
+type FileTree = {
+  [key: string]: FileTree | null;
+};
+
+function generateTreeRepresentation(
+  tree: FileTree,
+  depth = 0
+): string[] {
+  const result: string[] = [];
+  const entries = Object.entries(tree).sort(([a], [b]) =>
+    a.localeCompare(b)
+  );
+  for (let i = 0; i < entries.length; i++) {
+    const [name, subtree] = entries[i];
+    const prefix =
+      '  '.repeat(depth) + (i === entries.length - 1 ? '└─' : '├─');
+    result.push(subtree ? `${prefix} ${name}/` : `${prefix} ${name}`);
+    if (subtree) {
+      result.push(...generateTreeRepresentation(subtree, depth + 1));
+    }
+  }
+  return result;
+}
+
+describe('insertIntoTree', () => {
+  it('creates a nested tree structure from file paths', () => {
+    const mockPaths = [
+      'packages/doc-chimp/src/index.ts',
+      'packages/doc-chimp/src/utils/helper.ts',
+      'packages/doc-chimp/README.md',
+      'packages/git-chimp/src/main.ts',
+      'packages/README.md',
+    ];
+
+    const tree: FileTree = {};
+
+    for (const file of mockPaths) {
+      const parts = file.split(path.sep);
+      insertIntoTree(tree, parts);
+    }
+
+    const output = generateTreeRepresentation(tree);
+
+    expect(output).toEqual([
+      '└─ packages/',
+      '  ├─ doc-chimp/',
+      '    ├─ README.md',
+      '    └─ src/',
+      '      ├─ index.ts',
+      '      └─ utils/',
+      '        └─ helper.ts',
+      '  ├─ git-chimp/',
+      '    └─ src/',
+      '      └─ main.ts',
+      '  └─ README.md',
+    ]);
+  });
+});


### PR DESCRIPTION
Well, well, well, look who decided to upgrade some package versions and add a new utility function. Here's a rundown of the changes you made:

1. Updated `chimp-core` to version 1.2.0 and `doc-chimp` to version 0.3.0. It's like a software makeover, just without the glamor.
2. Added a new dependency on `fast-glob` in both packages. Because who doesn't love a good game of dependency musical chairs?
3. Implemented an async function `getChalk` in `chimp-core/src/utils/getChalk.ts`. It's about time JavaScript embraced the world of promises.
4. Tweaked the CLI config handling in `chimp-core/src/cli/config.ts`. Who doesn't enjoy some async/await magic in their functions?
5. Enhanced the `overview` command in `doc-chimp` to display directory tree structures with color options. Because who doesn't want their terminal to look like a Christmas tree?

Reviewers, please pay attention to the new async functions and the revamped `overview` command. Keep your eyes open for any unexpected behavior or regressions. And remember, changing versions is like stepping on a minefield - proceed with caution.