### PR TITLE
chore: update tagFormat to @chimp-stack/core@${version} and @chimp-stack/doc-chimp@${version} [skip ci]

### DIFF
--- a/packages/chimp-core/.releaserc
+++ b/packages/chimp-core/.releaserc
@@ -1,14 +1,15 @@
 {
   "extends": "semantic-release-monorepo",
   "monorepoPath": "packages/chimp-core",
-  "tagFormat": "chimp-core@${version}",
+  "tagFormat": "@chimp-stack/core@${version}",
   "plugins": [
     ["@semantic-release/commit-analyzer"],
     ["@semantic-release/release-notes-generator"],
     ["@semantic-release/npm"],
     ["@semantic-release/github", {
-      "releaseName": "chimp-core v${nextRelease.version}",
-      "message": "chore(release): 🚀 release chimp-core@${nextRelease.version} [skip ci]"
+      "releaseName": "@chimp-stack/core v${nextRelease.version}",
+      "message": "chore(release): 🚀 release @chimp-stack/core@${nextRelease.version} [skip ci]"
     }]
-  ]
+  ],
+  "initialReleaseVersion": "1.6.0"
 }

--- a/packages/chimp-core/package.json
+++ b/packages/chimp-core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "chimp-core",
+  "name": "@chimp-stack/core",
   "version": "1.5.0",
   "files": [
     "dist"

--- a/packages/chimp-core/src/index.ts
+++ b/packages/chimp-core/src/index.ts
@@ -4,3 +4,4 @@ export * from './cli/addChimpConfigCommand';
 export * from './cli/config';
 export * from './cli/init';
 export * from './types/config';
+export * from './utils/logger';

--- a/packages/chimp-core/src/utils/logger.ts
+++ b/packages/chimp-core/src/utils/logger.ts
@@ -1,0 +1,26 @@
+import { getChalk } from 'src/utils/getChalk';
+
+export async function logInfo(msg: string) {
+  const chalk = await getChalk();
+  console.log(chalk.blue(`[chimp] ${msg}`));
+}
+
+export async function logSuccess(msg: string) {
+  const chalk = await getChalk();
+  console.log(chalk.green(`[chimp] ${msg}`));
+}
+
+export async function logWarn(msg: string) {
+  const chalk = await getChalk();
+  console.log(chalk.yellow(`[chimp] ${msg}`));
+}
+
+export async function logError(msg: string) {
+  const chalk = await getChalk();
+  console.error(chalk.red(`[chimp] ${msg}`));
+}
+
+export async function logMuted(msg: string) {
+  const chalk = await getChalk();
+  console.log(chalk.gray(`[chimp] ${msg}`));
+}

--- a/packages/doc-chimp/.releaserc
+++ b/packages/doc-chimp/.releaserc
@@ -1,14 +1,15 @@
 {
   "extends": "semantic-release-monorepo",
   "monorepoPath": "packages/doc-chimp",
-  "tagFormat": "doc-chimp@${version}",
+  "tagFormat": "@chimp-stack/doc-chimp@${version}",
   "plugins": [
     ["@semantic-release/commit-analyzer"],
     ["@semantic-release/release-notes-generator"],
     ["@semantic-release/npm"],
     ["@semantic-release/github", {
-      "releaseName": "doc-chimp v${nextRelease.version}",
-      "message": "chore(release): 🚀 release doc-chimp@${nextRelease.version} [skip ci]"
+      "releaseName": "@chimp-stack/doc-chimp v${nextRelease.version}",
+      "message": "chore(release): 🚀 release @chimp-stack/doc-chimp@${nextRelease.version} [skip ci]"
     }]
-  ]
+  ],
+  "initialReleaseVersion": "0.7.0"
 }

--- a/packages/doc-chimp/package.json
+++ b/packages/doc-chimp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "doc-chimp",
+  "name": "@chimp-stack/doc-chimp",
   "version": "0.6.0",
   "type": "module",
   "bin": {

--- a/packages/doc-chimp/package.json
+++ b/packages/doc-chimp/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@types/node": "^22.15.29",
     "chalk": "^5.4.1",
-    "chimp-core": "*",
+    "@chimp-stack/core": "*",
     "commander": "^14.0.0",
     "comment-parser": "^1.4.1",
     "fast-glob": "^3.3.3",

--- a/packages/git-chimp/.releaserc
+++ b/packages/git-chimp/.releaserc
@@ -1,14 +1,15 @@
 {
   "extends": "semantic-release-monorepo",
   "monorepoPath": "packages/git-chimp",
-  "tagFormat": "git-chimp@${version}",
+  "tagFormat": "@chimp-stack/git-chimp@${version}",
   "plugins": [
     ["@semantic-release/commit-analyzer"],
     ["@semantic-release/release-notes-generator"],
     ["@semantic-release/npm"],
     ["@semantic-release/github", {
-      "releaseName": "git-chimp v${nextRelease.version}",
-      "message": "chore(release): 🚀 release git-chimp@${nextRelease.version} [skip ci]"
+      "releaseName": "@chimp-stack/git-chimp v${nextRelease.version}",
+      "message": "chore(release): 🚀 release @chimp-stack/git-chimp@${nextRelease.version} [skip ci]"
     }]
-  ]
+  ],
+  "initialReleaseVersion": "0.12.0"
 }

--- a/packages/git-chimp/package.json
+++ b/packages/git-chimp/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@octokit/rest": "^22.0.0",
     "chalk": "^5.4.1",
-    "chimp-core": "*",
+    "@chimp-stack/core": "*",
     "commander": "^14.0.0",
     "dotenv": "^16.5.0",
     "inquirer": "^12.6.3",

--- a/packages/git-chimp/package.json
+++ b/packages/git-chimp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "git-chimp",
+  "name": "@chimp-stack/git-chimp",
   "version": "0.11.0",
   "scripts": {
     "clean": "rm -rf dist",

--- a/packages/git-chimp/src/commands/changelog.ts
+++ b/packages/git-chimp/src/commands/changelog.ts
@@ -1,9 +1,14 @@
 import { simpleGit } from 'simple-git';
-import chalk from 'chalk';
 import fs from 'fs';
 import type { DefaultLogFields, ListLogLine } from 'simple-git';
 import { generateChangelogEntries } from '../lib/openai.js'; // New helper
-import { GitChimpConfig, loadChimpConfig } from 'chimp-core';
+import {
+  GitChimpConfig,
+  loadChimpConfig,
+  logError,
+  logSuccess,
+  logWarn,
+} from 'chimp-core';
 
 export async function handleChangelog(
   options: {
@@ -20,10 +25,8 @@ export async function handleChangelog(
   const to = options.to || 'HEAD';
 
   if (!from) {
-    console.error(
-      chalk.red(
-        '❌ No tags found to use as a starting point. Use --from manually.'
-      )
+    logError(
+      '❌ No tags found to use as a starting point. Use --from manually.'
     );
     process.exit(1);
   }
@@ -32,9 +35,7 @@ export async function handleChangelog(
   const commits: (DefaultLogFields & ListLogLine)[] = [...log.all];
 
   if (commits.length === 0) {
-    console.log(
-      chalk.yellow('⚠️ No commits found between specified tags.')
-    );
+    logWarn('⚠️ No commits found between specified tags.');
     process.exit(0);
   }
 
@@ -84,9 +85,7 @@ export async function handleChangelog(
 
   if (options.output) {
     fs.appendFileSync(options.output, output);
-    console.log(
-      chalk.green(`✅ Changelog written to ${options.output}`)
-    );
+    logSuccess(`✅ Changelog written to ${options.output}`);
   } else {
     console.log(output);
   }

--- a/packages/git-chimp/src/commands/commit.ts
+++ b/packages/git-chimp/src/commands/commit.ts
@@ -1,10 +1,15 @@
 import { generateCommitMessages } from '../lib/openai.js';
 import { simpleGit } from 'simple-git';
 import inquirer from 'inquirer';
-import chalk from 'chalk';
 import { cleanCommitMessages } from '../utils/format.js';
 import { isConventionalCommit } from '../utils/git.js';
-import { GitChimpConfig, loadChimpConfig } from 'chimp-core';
+import {
+  GitChimpConfig,
+  loadChimpConfig,
+  logError,
+  logWarn,
+  logSuccess,
+} from 'chimp-core';
 
 const git = simpleGit();
 
@@ -32,7 +37,7 @@ export async function handleCommitCommand(
     const diff = await git.diff(['--staged']);
 
     if (!diff) {
-      console.log(chalk.yellow('⚠️ No staged changes found.'));
+      logWarn('⚠️ No staged changes found.');
       process.exit(0);
     }
 
@@ -48,21 +53,18 @@ export async function handleCommitCommand(
         },
       ]);
       if (enforceCommits && !isConventionalCommit(customMessage)) {
-        console.log(
-          chalk.red(
-            '❌ Commit message does not follow Conventional Commit format.'
-          )
+        logError(
+          '❌ Commit message does not follow Conventional Commit format.'
         );
-        console.log(
-          chalk.yellow(
-            'Expected format: "type(scope): description"\nExample: "feat(auth): add login button"'
-          )
+
+        logWarn(
+          'Expected format: "type(scope): description"\nExample: "feat(auth): add login button"'
         );
         process.exit(1);
       }
 
       await git.commit(customMessage);
-      console.log(chalk.green('✅ Commit created!'));
+      logSuccess('✅ Commit created!');
       process.exit(0);
     }
 
@@ -123,21 +125,17 @@ export async function handleCommitCommand(
     }
 
     if (enforceCommits && !isConventionalCommit(finalMessage)) {
-      console.log(
-        chalk.red(
-          '❌ Commit message does not follow Conventional Commit format.'
-        )
+      logError(
+        '❌ Commit message does not follow Conventional Commit format.'
       );
-      console.log(
-        chalk.yellow(
-          'Expected format: "type(scope): description"\nExample: "feat(auth): add login button"'
-        )
+      logWarn(
+        'Expected format: "type(scope): description"\nExample: "feat(auth): add login button"'
       );
       process.exit(1);
     }
     await git.commit(finalMessage);
-    console.log(chalk.green('✅ Commit created!'));
+    logSuccess('✅ Commit created!');
   } catch (error) {
-    console.error(chalk.red('❌ Error creating commit:'), error);
+    logError(`❌ Error creating commit: ${error}`);
   }
 }

--- a/packages/git-chimp/src/utils/git.ts
+++ b/packages/git-chimp/src/utils/git.ts
@@ -1,5 +1,4 @@
-import chalk from 'chalk';
-import { GitChimpConfig } from 'chimp-core';
+import { GitChimpConfig, logWarn } from 'chimp-core';
 
 export function guessSemanticPrefix(diff: string): string {
   const lowerDiff = diff.toLowerCase();
@@ -54,7 +53,7 @@ export function validatePrTitle(
     if (opts.throwOnError) {
       throw new Error(msg);
     } else {
-      console.warn(chalk.yellow(msg));
+      logWarn(msg);
     }
   }
 


### PR DESCRIPTION
### Changes Summary 🚀

Wow, a lot of exciting updates in this pull request! Here's a snarky summary just for kicks:

- Renamed tag format from "chimp-core" to "@chimp-stack/core" because who needs consistency, right?
- Added a new logger utility for chimp-core - because debugging was just too easy before.
- Changed package names for doc-chimp and git-chimp to "@chimp-stack/doc-chimp" and "@chimp-stack/git-chimp" - consistency is overrated anyway.
- Updated initial release version for chimp-core, doc-chimp, and git-chimp because versioning is just a social construct, right?
- Tweaked some code in git-chimp to enhance the commit and pull request handling - because why make things easy for ourselves?

### Context ℹ️

These changes randomize things a bit, with updated formats, new utilities, and version tweaks. So buckle up for some surprise challenges, because consistency is too mainstream!

### Reviewer Notes 🧐

Watch out for the sudden shift in naming conventions - the code is feeling rebellious. Also, keep an eye on the new logger utility and changes in handling commits and pull requests - expect the unexpected!

Feel free to dive into the code and embrace the chaos 🎉